### PR TITLE
add html5 for distill

### DIFF
--- a/R/knit.R
+++ b/R/knit.R
@@ -7,7 +7,7 @@ knit_print.icon <- function(x, ...) {
     warn("Could not detect output format, please use `rmarkdown::render()` to knit the document.")
     return(knitr::asis_output(""))
   }
-  if(out_type %in% c("html", "markdown_strict")){
+  if(out_type %in% c("html", "html5", "markdown_strict")){
     return(knitr::asis_output(gsub('\n', "", format(x))))
   }
 


### PR DESCRIPTION
Looks like the distill package returns `html5` in response to `knitr::opts_knit$get("rmarkdown.pandoc.to")` which means that the **icon** package currently complains about `Icons for this format is currently not supported` for distill. Adding `"html5"` as an option in knit.R seems to fix the issue, but I haven't tested widely and I'm not sure if this is just a naiive hack.